### PR TITLE
fix: add error log

### DIFF
--- a/controller/tke-cluster-config-handler.go
+++ b/controller/tke-cluster-config-handler.go
@@ -101,6 +101,7 @@ func (h *Handler) recordError(onChange func(key string, config *tkev1.TKECluster
 		}
 		if err != nil {
 			message = err.Error()
+			logrus.Errorf("TKEClusterConfig [%s] sync error: %v", config.Name, err)
 		}
 
 		if config.Status.FailureMessage == message {
@@ -376,6 +377,7 @@ func (h *Handler) updateUpstreamClusterState(driver *tcdriver.Driver, config *tk
 		if np.NodePoolID == "" {
 			responseNodePoolId, err := driver.TKEClient.CreateClusterNodePool(config.Spec.ClusterID, np)
 			if err != nil {
+				logrus.Errorf("cluster [%s] failed to create node pool [%s]: %v", config.Name, np.Name, err)
 				return config, err
 			}
 			config.Spec.NodePoolList[index].NodePoolID = *responseNodePoolId


### PR DESCRIPTION
add error logs so that the log will record error reason:
```
ERRO[0189] TKEClusterConfig [c-vnhvc] sync error: [TencentCloudSDKError] Code=FailedOperation.AsCommon, Message=AS_COMMON_ERROR(err:[TencentCloudSDKError] Code=InvalidParameterValue.CvmConfigurationError, Message=云服务器错误码：`InvalidParameter`，错误信息：`[19001]当前分区不支持所需云硬盘类型`，CvmRequestId：`69e1e4ac-b317-4c24-8a7d-da06803d9011`，实例类型：`SA9.MEDIUM4`。, RequestId=28e983d7-83c3-48b0-bc8f-67e6269766cf), RequestId=d2ac333b-9a2e-4233-9369-a96d2aa782fd 
```