### PR TITLE
fix:  delete node pool before deleting tke clusters/handle k8s version upgrades/handle issues of creating multi same clusters occasionally

### DIFF
--- a/controller/tke-cluster-config-handler.go
+++ b/controller/tke-cluster-config-handler.go
@@ -141,21 +141,87 @@ func (h *Handler) OnTkeConfigRemoved(key string, config *tkev1.TKEClusterConfig)
 	}
 
 	if err := wait.ExponentialBackoff(backoff, func() (bool, error) {
-		if config.Spec.ClusterID != "" {
-			driver, err := tcdriver.GetDriver(h.secretsCache, config.Spec.TKECredentialSecret, config.Spec.Region)
-			if err != nil {
-				return false, err
-			}
+		if config.Spec.ClusterID == "" {
+			logrus.Infof("cluster [%s] has no ClusterID, already deleted", config.Name)
+			return true, nil
+		}
 
-			logrus.Infof("removing cluster %v , region %v", config.Name, config.Spec.Region)
-			if err := driver.TKEClient.DeleteCluster(config.Spec.ClusterID); err != nil {
-				if sdkErr, ok := err.(*tcerrors.TencentCloudSDKError); ok && sdkErr.Code == tkeapi.FAILEDOPERATION_CLUSTERNOTFOUND {
-					logrus.Infof("cluster %v , region %v already removed", config.Name, config.Spec.Region)
+		driver, err := tcdriver.GetDriver(h.secretsCache, config.Spec.TKECredentialSecret, config.Spec.Region)
+		if err != nil {
+			return false, err
+		}
+
+		// Check and delete node pools first
+		nodePools, err := driver.TKEClient.GetClusterNodePools(config.Spec.ClusterID)
+		if err != nil {
+			// If cluster not found, it means cluster is already deleted
+			if sdkErr, ok := err.(*tcerrors.TencentCloudSDKError); ok {
+				if sdkErr.Code == tkeapi.FAILEDOPERATION_CLUSTERNOTFOUND {
+					logrus.Infof("cluster [%s] not found, already removed", config.Name)
 					return true, nil
 				}
-				return false, err
 			}
+			logrus.Warnf("failed to get node pools for cluster [%s]: %v", config.Name, err)
+			return false, err
 		}
+
+		// If there are node pools, delete them first and wait
+		if len(nodePools) > 0 {
+			var needDeletePoolIds []*string
+			for _, np := range nodePools {
+				if np.NodePoolId == nil || *np.NodePoolId == "" {
+					continue
+				}
+				// Only delete node pools that are not being deleted yet
+				if np.LifeState != nil {
+					state := *np.LifeState
+					if state == tcdriver.NodePoolStatusDeleting || state == tcdriver.NodePoolStatusDeleted {
+						// Already being deleted, skip
+						continue
+					}
+				}
+				needDeletePoolIds = append(needDeletePoolIds, np.NodePoolId)
+			}
+
+			// Request deletion for node pools that need it
+			if len(needDeletePoolIds) > 0 {
+				logrus.Infof("requesting deletion of %d node pool(s) for cluster [%s]", len(needDeletePoolIds), config.Name)
+				if err := driver.TKEClient.DeleteNodePool(config.Spec.ClusterID, needDeletePoolIds); err != nil {
+					if sdkErr, ok := err.(*tcerrors.TencentCloudSDKError); ok {
+						if sdkErr.Code == "ResourceNotFound.NodePoolNotFound" {
+							// Already deleted, continue waiting
+							logrus.Infof("node pools already deleted for cluster [%s]", config.Name)
+						} else {
+							logrus.Errorf("failed to delete node pools for cluster [%s]: %v", config.Name, err)
+							return false, err
+						}
+					} else {
+						logrus.Errorf("failed to delete node pools for cluster [%s]: %v", config.Name, err)
+						return false, err
+					}
+				}
+			}
+
+			// Wait for all node pools to be deleted (regardless of whether we just requested deletion)
+			logrus.Infof("cluster [%s] still has %d node pool(s), waiting for deletion to complete", config.Name, len(nodePools))
+			return false, nil
+		}
+
+		// All node pools deleted, now delete the cluster
+		logrus.Infof("removing cluster %v, region %v", config.Name, config.Spec.Region)
+		if err := driver.TKEClient.DeleteCluster(config.Spec.ClusterID); err != nil {
+			if sdkErr, ok := err.(*tcerrors.TencentCloudSDKError); ok {
+				if sdkErr.Code == tkeapi.FAILEDOPERATION_CLUSTERNOTFOUND {
+					logrus.Infof("cluster %v, region %v already removed", config.Name, config.Spec.Region)
+					return true, nil
+				}
+			}
+			// Any other error should be reported
+			logrus.Errorf("failed to delete cluster [%v]: %v", config.Name, err)
+			return false, err
+		}
+
+		logrus.Infof("cluster %v deletion requested successfully", config.Name)
 		return true, nil
 	}); err != nil {
 		return config, err

--- a/controller/tke-cluster-config-handler.go
+++ b/controller/tke-cluster-config-handler.go
@@ -381,6 +381,20 @@ func (h *Handler) checkAndUpdate(config *tkev1.TKEClusterConfig) (*tkev1.TKEClus
 
 // updateUpstreamClusterState sync config to upstream cluster
 func (h *Handler) updateUpstreamClusterState(driver *tcdriver.Driver, config *tkev1.TKEClusterConfig, upstreamSpec *tkev1.TKEClusterConfigSpec) (*tkev1.TKEClusterConfig, error) {
+	// Check kubernetes version for upgrade cluster.
+	if config.Spec.ClusterBasicSettings != nil && upstreamSpec.ClusterBasicSettings != nil {
+		if config.Spec.ClusterBasicSettings.ClusterVersion != upstreamSpec.ClusterBasicSettings.ClusterVersion {
+			logrus.Infof("cluster [%s] version upgrade detected: %s -> %s",
+				config.Name,
+				upstreamSpec.ClusterBasicSettings.ClusterVersion,
+				config.Spec.ClusterBasicSettings.ClusterVersion)
+			if _, err := driver.TKEClient.UpdateClusterVersion(&config.Spec); err != nil {
+				return config, err
+			}
+			return h.enqueueUpdate(config)
+		}
+	}
+
 	if config.Spec.ClusterBasicSettings != nil && config.Spec.ClusterAdvancedSettings != nil {
 		if config.Spec.ClusterBasicSettings.ProjectID != upstreamSpec.ClusterBasicSettings.ProjectID ||
 			config.Spec.ClusterBasicSettings.ClusterName != upstreamSpec.ClusterBasicSettings.ClusterName ||

--- a/controller/tke-cluster-config-handler.go
+++ b/controller/tke-cluster-config-handler.go
@@ -42,6 +42,7 @@ var backoff = wait.Backoff{
 
 type Handler struct {
 	tkeCC           v12.TKEClusterConfigClient
+	tkeCache        v12.TKEClusterConfigCache
 	tkeEnqueueAfter func(namespace, name string, duration time.Duration)
 	tkeEnqueue      func(namespace, name string)
 	secrets         wranglerv1.SecretClient
@@ -55,6 +56,7 @@ func Register(
 
 	controller := &Handler{
 		tkeCC:           tke,
+		tkeCache:        tke.Cache(),
 		tkeEnqueue:      tke.Enqueue,
 		tkeEnqueueAfter: tke.EnqueueAfter,
 		secretsCache:    secrets.Cache(),
@@ -227,17 +229,51 @@ func (h *Handler) create(config *tkev1.TKEClusterConfig) (*tkev1.TKEClusterConfi
 			return config, err
 		}
 
-		configUpdate := config.DeepCopy()
-		configUpdate.Spec.ClusterID = *responseClusterId
-		configUpdate, err = h.tkeCC.Update(configUpdate)
+		// Use RetryOnConflict to prevent repeated creation when Update fails
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			result, getErr := h.tkeCache.Get(config.Namespace, config.Name)
+			if getErr != nil {
+				return fmt.Errorf("failed to get tkeConfig from cache: %w", getErr)
+			}
+			if result.Spec.ClusterID == *responseClusterId {
+				config = result
+				return nil
+			}
+
+			result = result.DeepCopy()
+			result.Spec.ClusterID = *responseClusterId
+			result, getErr = h.tkeCC.Update(result)
+			if getErr != nil {
+				return getErr
+			}
+			config = result
+			return nil
+		})
 		if err != nil {
 			return config, err
 		}
 
-		logrus.Infof("current cluster id: %s", configUpdate.Spec.ClusterID)
-		configStatus := configUpdate.DeepCopy()
-		configStatus.Status.Phase = tkeConfigCreatingPhase
-		config, err = h.tkeCC.UpdateStatus(configStatus)
+		logrus.Infof("current cluster id: %s", config.Spec.ClusterID)
+		// Update status to creating phase
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			result, getErr := h.tkeCache.Get(config.Namespace, config.Name)
+			if getErr != nil {
+				return getErr
+			}
+			if result.Status.Phase == tkeConfigCreatingPhase && result.Status.FailureMessage == "" {
+				config = result
+				return nil
+			}
+			result = result.DeepCopy()
+			result.Status.Phase = tkeConfigCreatingPhase
+			result.Status.FailureMessage = ""
+			result, getErr = h.tkeCC.UpdateStatus(result)
+			if getErr != nil {
+				return getErr
+			}
+			config = result
+			return nil
+		})
 		if err != nil {
 			return config, err
 		}

--- a/driver/client/tke.go
+++ b/driver/client/tke.go
@@ -411,11 +411,14 @@ func (t TKEClient) UpdateClusterVersion(configSpec *tkev1.TKEClusterConfigSpec) 
 	request := tkeapi.NewUpdateClusterVersionRequest()
 	request.ClusterId = &configSpec.ClusterID
 	request.DstVersion = &configSpec.ClusterBasicSettings.ClusterVersion
-	request.ExtraArgs = &tkeapi.ClusterExtraArgs{
-		KubeAPIServer:         utils.ParseStrings(configSpec.ClusterAdvancedSettings.KubeAPIServer),
-		KubeControllerManager: utils.ParseStrings(configSpec.ClusterAdvancedSettings.KubeControllerManager),
-		KubeScheduler:         utils.ParseStrings(configSpec.ClusterAdvancedSettings.KubeScheduler),
-		Etcd:                  utils.ParseStrings(configSpec.ClusterAdvancedSettings.Etcd),
+	// Only set ExtraArgs when ClusterAdvancedSettings is present; otherwise leave nil for API default.
+	if configSpec.ClusterAdvancedSettings != nil {
+		request.ExtraArgs = &tkeapi.ClusterExtraArgs{
+			KubeAPIServer:         utils.ParseStrings(configSpec.ClusterAdvancedSettings.KubeAPIServer),
+			KubeControllerManager: utils.ParseStrings(configSpec.ClusterAdvancedSettings.KubeControllerManager),
+			KubeScheduler:         utils.ParseStrings(configSpec.ClusterAdvancedSettings.KubeScheduler),
+			Etcd:                  utils.ParseStrings(configSpec.ClusterAdvancedSettings.Etcd),
+		}
 	}
 
 	response, err := t.client.UpdateClusterVersion(request)


### PR DESCRIPTION
fix some issues:
1. delete node pool before deleting tke clusters to resolve the issue of needing to manually delete the node pool.
2. add code to handle k8s version upgrades
3. add code to handle concurrent conflices to resolve the occasional issue of creating two clusters with the same name.
