### PR TITLE
fix: modify SecurityGroupIDs+ do not auto generate displayname+use cluster.spec content for EnableAutoscale when sync upstream cluster

### DIFF
--- a/controller/tke-cluster-config-handler.go
+++ b/controller/tke-cluster-config-handler.go
@@ -1057,6 +1057,15 @@ func FixConfig(driver *tcdriver.Driver, configSpec *tkev1.TKEClusterConfigSpec, 
 		NetworkType:        parseNetworkTypeFromProperty(cluster.Property),
 	}
 
+	// Index the existing NodePoolList by NodePoolID so we can preserve fields that the
+	// DescribeClusterNodePools API does not return (e.g. EnableAutoscale).
+	existingNodePoolByID := make(map[string]tkev1.NodePoolDetail, len(configSpec.NodePoolList))
+	for _, np := range configSpec.NodePoolList {
+		if np.NodePoolID != "" {
+			existingNodePoolByID[np.NodePoolID] = np
+		}
+	}
+
 	var nodePoolList []tkev1.NodePoolDetail
 	for _, nodePool := range nodePools {
 		autoScalingGroup, err := driver.ASClient.GetAutoScalingGroups(nodePool.AutoscalingGroupId)
@@ -1071,6 +1080,7 @@ func FixConfig(driver *tcdriver.Driver, configSpec *tkev1.TKEClusterConfigSpec, 
 			continue
 		}
 
+		existing := existingNodePoolByID[*nodePool.NodePoolId]
 		nodePoolList = append(nodePoolList, tkev1.NodePoolDetail{
 			ClusterID:  *cluster.ClusterId,
 			NodePoolID: *nodePool.NodePoolId,
@@ -1095,6 +1105,8 @@ func FixConfig(driver *tcdriver.Driver, configSpec *tkev1.TKEClusterConfigSpec, 
 				SecurityGroupIDs:        utils.ParseStringsPointer(launchConfiguration.SecurityGroupIds),
 				InstanceChargeType:      *launchConfiguration.InstanceChargeType,
 			},
+			// EnableAutoscale is not returned by DescribeClusterNodePools; preserve from existing spec.
+			EnableAutoscale:    existing.EnableAutoscale,
 			Name:               *nodePool.Name,
 			Labels:             utils.ParseLabelsString(nodePool.Labels),
 			Taints:             utils.ParseTaintsString(nodePool.Taints),

--- a/driver/client/tke.go
+++ b/driver/client/tke.go
@@ -658,17 +658,14 @@ func (t TKEClient) CreateClusterVirtualNodePool(clusterId string, pool tkev1.Vir
 		}
 	}
 	if len(pool.VirtualNodes) > 0 {
-		for i, vn := range pool.VirtualNodes {
+		for _, vn := range pool.VirtualNodes {
 			vnCopy := vn
-			displayName := vnCopy.DisplayName
-			// Tencent Cloud may treat multiple VirtualNodes with the same SubnetId and empty
-			// DisplayName as one node. Assign a unique DisplayName so each entry becomes a node.
-			if displayName == "" {
-				displayName = fmt.Sprintf("node-%d", i)
-			}
 			spec := &tkeapi.VirtualNodeSpec{
-				DisplayName: &displayName,
-				SubnetId:    &vnCopy.SubnetId,
+				SubnetId: &vnCopy.SubnetId,
+			}
+			if vnCopy.DisplayName != "" {
+				dn := vnCopy.DisplayName
+				spec.DisplayName = &dn
 			}
 			for _, tag := range vnCopy.Tags {
 				tagCopy := tag

--- a/driver/client/tke.go
+++ b/driver/client/tke.go
@@ -779,7 +779,7 @@ func (t TKEClient) GetClusterVirtualNodePoolsFull(clusterId string) ([]tkeapiful
 		return nil, err
 	}
 	raw := resp.GetBody()
-	logrus.Debugf("DescribeClusterVirtualNodePools raw response: %s", string(raw))
+	logrus.Infof("DescribeClusterVirtualNodePools raw response: %s", string(raw))
 	return tkeapifull.ParseDescribeClusterVirtualNodePoolsResponse(raw)
 }
 

--- a/utils/parse.go
+++ b/utils/parse.go
@@ -327,6 +327,18 @@ func DiffVirtualNodePoolModifyFields(desired, upstream tkev1.VirtualNodePoolDeta
 			f.DeletionProtection = &v
 		}
 	}
+	// ModifyClusterVirtualNodePool SDK decides "nothing is updated" from a subset of
+	// fields and can ignore SecurityGroupIds. Always send Name when anything else
+	// changed so SG-only updates are accepted; unchanged name uses upstream.
+	if !f.Empty() && f.Name == nil {
+		name := upstream.Name
+		if desired.Name != "" {
+			name = desired.Name
+		}
+		if name != "" {
+			f.Name = &name
+		}
+	}
 	if f.Empty() {
 		return nil
 	}


### PR DESCRIPTION
1. only change SecurityGroupIDs invalid, must add others filed, this is sdk bug
2. do not auto generate displayname
3. use cluster.spec content for EnableAutoscale when sync upstream cluster