### PR TITLE
fix: recreate endpoint when create failed.

### DIFF
--- a/controller/tke-cluster-config-handler.go
+++ b/controller/tke-cluster-config-handler.go
@@ -911,12 +911,13 @@ func (h *Handler) updateUpstreamClusterState(driver *tcdriver.Driver, config *tk
 
 	if !config.Spec.Imported {
 		logrus.Infof("cluster endpoint enable")
-		endpointStatus, err := driver.TKEClient.GetClusterEndpointStatus(config.Spec.ClusterID, config.Spec.ClusterEndpoint.Enable)
+		endpointStatus, endpointErrMsg, err := driver.TKEClient.GetClusterEndpointStatus(config.Spec.ClusterID, config.Spec.ClusterEndpoint.Enable)
 		if err != nil {
 			return config, err
 		}
 
-		switch *endpointStatus {
+		logrus.Infof("cluster [%s] endpoint status is %s", config.Name, endpointStatus)
+		switch endpointStatus {
 		case tcdriver.EndpointStatusCreated:
 			if err = h.createCASecret(driver, config); err != nil {
 				return config, err
@@ -952,6 +953,18 @@ func (h *Handler) updateUpstreamClusterState(driver *tcdriver.Driver, config *tk
 			return config, nil
 		case tcdriver.EndpointStatusCreating:
 			logrus.Infof("waiting for cluster [%s] endpoint to finish creating", config.Name)
+			h.tkeEnqueueAfter(config.Namespace, config.Name, waitSecond*time.Second)
+			return config, nil
+		case tcdriver.EndpointStatusCreateFailed:
+			// Endpoint creation failed asynchronously (e.g. service-controller not running).
+			// Delete the failed endpoint to reset state back to NotFound, then re-enqueue so
+			// the NotFound case can re-create it on the next reconcile.
+			logrus.Errorf("cluster [%s] endpoint CreateFailed: %s", config.Name, endpointErrMsg)
+			if delErr := driver.TKEClient.DeleteClusterEndpoints(config.Spec.ClusterID, config.Spec.ClusterEndpoint.Enable); delErr != nil {
+				// Deletion may be rejected if another operation is in progress (e.g. RESOURCEINUSE).
+				// Log and continue: next reconcile will retry.
+				logrus.Warnf("cluster [%s] failed to delete CreateFailed endpoint: %v", config.Name, delErr)
+			}
 			h.tkeEnqueueAfter(config.Namespace, config.Name, waitSecond*time.Second)
 			return config, nil
 		}

--- a/driver/client/tke.go
+++ b/driver/client/tke.go
@@ -593,7 +593,9 @@ func (t TKEClient) GetClusterEndpoints(clusterId string) (*tkeapi.DescribeCluste
 	return response, nil
 }
 
-func (t TKEClient) GetClusterEndpointStatus(clusterId string, extranet bool) (*string, error) {
+// GetClusterEndpointStatus returns the endpoint status and an optional error message from TKE.
+// The errorMsg is non-empty only when status is "CreateFailed".
+func (t TKEClient) GetClusterEndpointStatus(clusterId string, extranet bool) (status string, errorMsg string, err error) {
 	logrus.Infof("client tke action: GetClusterEndpointStatus")
 	request := tkeapi.NewDescribeClusterEndpointStatusRequest()
 	request.ClusterId = &clusterId
@@ -601,14 +603,30 @@ func (t TKEClient) GetClusterEndpointStatus(clusterId string, extranet bool) (*s
 
 	response, err := t.client.DescribeClusterEndpointStatus(request)
 	if err != nil {
-		return nil, err
+		return "", "", err
 	}
 
 	if response.Response == nil || response.Response.Status == nil {
-		return nil, fmt.Errorf("error while getting response")
+		return "", "", fmt.Errorf("error while getting response")
 	}
 
-	return response.Response.Status, nil
+	if response.Response.ErrorMsg != nil {
+		errorMsg = *response.Response.ErrorMsg
+	}
+	return *response.Response.Status, errorMsg, nil
+}
+
+func (t TKEClient) DeleteClusterEndpoints(clusterId string, extranet bool) error {
+	logrus.Infof("client tke action: DeleteClusterEndpoints")
+	request := tkeapi.NewDeleteClusterEndpointRequest()
+	request.ClusterId = &clusterId
+	request.IsExtranet = tccommon.BoolPtr(extranet)
+
+	if _, err := t.client.DeleteClusterEndpoint(request); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (t TKEClient) CreateClusterEndpoints(spec tkev1.TKEClusterConfigSpec, extranet bool) error {

--- a/driver/common.go
+++ b/driver/common.go
@@ -31,9 +31,10 @@ const (
 
 // state of endpoint
 const (
-	EndpointStatusCreated  = "Created"
-	EndpointStatusCreating = "Creating"
-	EndpointStatusNotFound = "NotFound"
+	EndpointStatusCreated      = "Created"
+	EndpointStatusCreating     = "Creating"
+	EndpointStatusNotFound     = "NotFound"
+	EndpointStatusCreateFailed = "CreateFailed"
 )
 
 // state of instance


### PR DESCRIPTION
[Issue 3888](https://github.com/cnrancher/pandaria/issues/3888)
recreate endpoint when create failed.